### PR TITLE
Update NixOS Wiki link

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The following resources might be useful when writing Nix:
 
 - <https://wiki.nixos.org/>
 - <https://nix.dev/>
-- <https://nixos.wiki/wiki/Flakes>
+- <https://wiki.nixos.org/wiki/Flakes>
 - <https://nixos.org/manual/nixpkgs/stable/#chap-functions>
 - <https://nixos.org/manual/nix/unstable/introduction.html>
 - <https://teu5us.github.io/nix-lib.html>
@@ -98,7 +98,7 @@ pkgs.mkShell {
 
 Potential alternatives for a Nix cache (instead of Hydra) are:
 
-- <https://nixos.wiki/wiki/Binary_Cache>
+- <https://wiki.nixos.org/wiki/Binary_Cache>
 - <https://github.com/helsinki-systems/harmonia>
 - <https://www.cachix.org/>
 - <https://github.com/edolstra/nix-serve>


### PR DESCRIPTION
Hello there 👋!

The NixOS wiki is in the process of migrating from https://nixos.wiki to https://wiki.nixos.org.
You can find more information about it [here](https://github.com/NixOS/foundation/issues/113).

You seem to be using the old link in your repository, which is why we send you this PR.
If you feel like this is not correct or have any questions, feel free to [get in touch with us](https://github.com/NixOS/nixos-wiki-infra/issues/105).


Have a great day,

-- The NixOS Wiki-Team ❄️